### PR TITLE
trying to get yaml that works cross-platform and without .condarc

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -1,6 +1,7 @@
 channels:
 - r
 - bioconda
+- conda-forge
 dependencies:
 - samtools=1.8
 - salmon=0.10.2
@@ -11,7 +12,7 @@ dependencies:
 - cutadapt=1.16
 - bedtools=2.27.1
 - ucsc-bedgraphtobigwig=366
-- r=3.4.3
+- r=3.4.1
 - r-dplyr
 - r-ggplot2
 - r-tidyr


### PR DESCRIPTION
- added `conda-forge` in list of channels otherwise problems with `multiqc`
- downgraded to `r=3.4.1` (from 3.4.3) otherwise `bioconductor-tximport` had a problem
- tested `conda env create -n rnaseqworkflow --file envs/environment.yaml` on both Mac (conda 4.5.6) and Ubuntu (conda 4.5.11) making sure to not have a .condarc file